### PR TITLE
check for ff, scoring, grid, alignment

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,7 +1,7 @@
 # TERNIFY: Efficient Sampling of PROTAC-Induced Ternary Complexes
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2025.05.29-green.svg)]()
+[![Version](https://img.shields.io/badge/version-2025.05.30-green.svg)]()
 
 TERNIFY is a high-performance C++ implementation for efficient sampling and prediction of PROTAC-induced ternary complex structures. It uses advanced molecular modeling techniques to predict how PROTAC molecules bring together E3 ligases and target proteins to form productive ternary complexes.
 
@@ -95,7 +95,7 @@ make -j 8
 
 # Optional: Install globally
 sudo cp ternify /usr/local/bin
-#=======
+=======
 # Run ternify
 ```
 
@@ -152,6 +152,9 @@ N_processes: 8        # Number of CPU threads
 RMSD_cutoff: 1.0      # RMSD threshold for clustering (Å)
 Verbose: 1            # Verbose level (0=quiet, 1=detailed)
 
+# Score_only mode (align to poi.sdf and e3.sdf,optimize H,then scoring )
+Score_only: 0
+
 # Interface definition (x_min, x_max, y_min, y_max, z_min, z_max)
 Interface: -15.0, 15.0, -15.0, 15.0, -15.0, 15.0
 ```
@@ -199,12 +202,12 @@ Interface: -15.0, 15.0, -15.0, 15.0, -15.0, 15.0
 
 TERNIFY calculates the following energy terms:
 
-- $ E_{intra} $ : Intramolecular PROTAC energy (VdW + torsional)
-- $ E_{anchor} $ : PROTAC-anchor protein interaction
-- $ E_{flex} $ : PROTAC-flexible protein interaction
-- $ E_{pp} $ : Protein-protein interaction energy
+- **E_intra**: Intramolecular PROTAC energy (VdW + torsional)
+- **E_anchor**: PROTAC-anchor protein interaction
+- **E_flex**: PROTAC-flexible protein interaction
+- **E_pp**: Protein-protein interaction energy
 
-$$ E_{total} = E_{intra} + E_{anchor} + E_{flex} + E_{pp} $$
+Total Energy = E_intra + E_anchor + E_flex + E_pp
 
 ## Performance Tips
 

--- a/cpp/src/align.hpp
+++ b/cpp/src/align.hpp
@@ -27,8 +27,8 @@ std::vector<std::array<double, 3>> Align(const std::vector<std::array<double, 3>
 
 // Align coordinates with a specific translation
 std::vector<std::array<double, 3>> Align2(const std::vector<std::array<double, 3>>& coords,
-                                            const std::vector<std::array<double, 3>>& coord_subs_var,
                                             const std::vector<std::array<double, 3>>& coord_ref,
+                                            const std::vector<std::array<double, 3>>& coord_subs_var,
                                             const std::array<double, 3>& translation);
 
 // 找出两个分子中对应的可旋转二面角

--- a/cpp/src/getgriden.cpp
+++ b/cpp/src/getgriden.cpp
@@ -1,5 +1,6 @@
 #include "getgriden.hpp"
 #include "parameters.hpp"
+#include <iostream>
 
 double GetGridEn(
     const GRID& grid,
@@ -19,8 +20,7 @@ double GetGridEn(
         // 检查坐标是否在网格范围内
         if (coor[0] >= grid_bounds[0][0] && coor[0] <= grid_bounds[0][1] &&
             coor[1] >= grid_bounds[1][0] && coor[1] <= grid_bounds[1][1] &&
-            coor[2] >= grid_bounds[2][0] && coor[2] <= grid_bounds[2][1]) {
-            
+            coor[2] >= grid_bounds[2][0] && coor[2] <= grid_bounds[2][1]) {            
             // 计算网格索引
             std::array<int, 3> loc;
             for (int j = 0; j < 3; ++j) {
@@ -31,114 +31,26 @@ double GetGridEn(
             const auto& voxel = grid_values[loc[0]][loc[1]][loc[2]];
             
             // 计算各项能量贡献
-            vdw += voxel.vdw_or_clash;
-            ele += voxel.elec * std::get<1>(q[i]);
+            double atom_vdw = voxel.vdw_or_clash;
+            double atom_ele = voxel.elec * std::get<1>(q[i]);
+            double atom_hb = 0.0;
             
             // 氢键计算
             auto hd_type = std::get<2>(q[i]);
             if (hd_type.has_value()) {
-                if (hd_type.value() == 2 && voxel.hd_donor.has_value()) { //体素记录的氢键角色要与移动中的角色保持一致
-                    hb += voxel.hd_acceptor.value();
-                } else if (hd_type.value() == 3 && voxel.hd_acceptor.has_value()) {
-                    hb += voxel.hd_donor.value();
+                if (hd_type.value() == 2 && voxel.hd_donor.has_value()) { // acceptor原子访问donor网格能量
+                    atom_hb = voxel.hd_donor.value();
+                } else if (hd_type.value() == 3 && voxel.hd_acceptor.has_value()) { // donor原子访问acceptor网格能量
+                    atom_hb = voxel.hd_acceptor.value();
                 }
             }
+            
+            vdw += atom_vdw;
+            ele += atom_ele;
+            hb += atom_hb;
         }
     }
-    
+
     return vdw + ele + hb;
 }
 
-/*
-GridEnergyResult GetGridEn(
-    const GRID& grid,
-    const Coords& coords,
-    const std::vector<IQHb>& q,
-    bool calc_derivs = false) {
-    
-    GridEnergyResult result{0.0};
-    if (calc_derivs) {
-        result.derivatives.resize(coords.size(), {0.0, 0.0, 0.0});
-    }
-
-    const auto& grid_values = grid.first;
-    const auto& grid_bounds = grid.second;
-    
-    for (size_t i = 0; i < coords.size(); ++i) {
-        const auto& coor = coords[i];
-        
-        // 检查坐标是否在网格范围内
-        if (coor[0] >= grid_bounds[0][0] && coor[0] <= grid_bounds[0][1] &&
-            coor[1] >= grid_bounds[1][0] && coor[1] <= grid_bounds[1][1] &&
-            coor[2] >= grid_bounds[2][0] && coor[2] <= grid_bounds[2][1]) {
-            
-            // 计算网格索引
-            std::array<int, 3> loc;
-            for (int j = 0; j < 3; ++j) {
-                loc[j] = static_cast<int>((coor[j] - grid_bounds[j][0]) / paras["grid_space"]);
-            }
-            
-            // 获取体素值
-            const auto& voxel = grid_values[loc[0]][loc[1]][loc[2]];
-            
-            // 计算总能量
-            double total_energy = voxel.vdw_or_clash;
-            total_energy += voxel.elec * std::get<1>(q[i]);
-            
-            // 氢键计算
-            auto hd_type = std::get<2>(q[i]);
-            if (hd_type.has_value()) {
-                if (hd_type.value() == 2 && voxel.hd_donor.has_value()) {
-                    total_energy += voxel.hd_acceptor.value();
-                } else if (hd_type.value() == 3 && voxel.hd_acceptor.has_value()) {
-                    total_energy += voxel.hd_donor.value();
-                }
-            }
-            
-            result.energy += total_energy;
-
-            // 如果需要计算导数
-            if (calc_derivs) {
-                // 对每个维度计算有限差分导数
-                for (int j = 0; j < 3; ++j) {
-                    if (loc[j] > 0 && loc[j] < static_cast<int>(grid_values.size())-1) {
-                        // 获取相邻格点的能量
-                        std::array<int, 3> loc_plus = loc;
-                        std::array<int, 3> loc_minus = loc;
-                        loc_plus[j]++;
-                        loc_minus[j]--;
-
-                        const auto& voxel_plus = grid_values[loc_plus[0]][loc_plus[1]][loc_plus[2]];
-                        const auto& voxel_minus = grid_values[loc_minus[0]][loc_minus[1]][loc_minus[2]];
-
-                        // 计算相邻格点的总能量
-                        double e_plus = voxel_plus.vdw_or_clash + voxel_plus.elec * std::get<1>(q[i]);
-                        double e_minus = voxel_minus.vdw_or_clash + voxel_minus.elec * std::get<1>(q[i]);
-
-                        // 添加氢键能量
-                        if (hd_type.has_value()) {
-                            if (hd_type.value() == 2) {
-                                if (voxel_plus.hd_donor.has_value()) 
-                                    e_plus += voxel_plus.hd_acceptor.value();
-                                if (voxel_minus.hd_donor.has_value()) 
-                                    e_minus += voxel_minus.hd_acceptor.value();
-                            } else if (hd_type.value() == 3) {
-                                if (voxel_plus.hd_acceptor.has_value()) 
-                                    e_plus += voxel_plus.hd_donor.value();
-                                if (voxel_minus.hd_acceptor.has_value()) 
-                                    e_minus += voxel_minus.hd_donor.value();
-                            }
-                        }
-
-                        // 计算中心差分导数
-                        result.derivatives[i][j] = (e_plus - e_minus) / (2.0 * paras["grid_space"]);
-                    }
-                }
-            }
-        }
-    }
-    
-    return result;
-}
-
-*/

--- a/cpp/src/getgriden.hpp
+++ b/cpp/src/getgriden.hpp
@@ -9,10 +9,3 @@ double GetGridEn(
     const GRID& grid,
     const Coords& coords,
     const std::vector<IQHb>& q);
-
-/*
-struct GridEnergyResult {
-    double energy;  // 总能量 (vdw + ele + hb)
-    std::vector<std::array<double, 3>> derivatives;  // 总能量对坐标的导数
-};
-*/

--- a/cpp/src/minimize_h.cpp
+++ b/cpp/src/minimize_h.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<RDKit::ROMol> MinimizeH(const RDKit::ROMol& input_mol, double fo
     }
     
     // 最小化氢原子位置
-    ff->minimize(1000);
+    ff->minimize(10000);
     
     return mol;
 }

--- a/cpp/src/parameters.cpp
+++ b/cpp/src/parameters.cpp
@@ -8,7 +8,7 @@ std::map<std::string, double> paras = {
     {"dist_clash", 2.4},
     {"lb_hbond_dist", 2.6},
     {"ub_hbond_dist", 3.8},
-    {"grid_space", 0.5},
+    {"grid_space", 0.3}, // 0.3 for py3 version
     {"rmin_6", std::pow(3.6, 6)},  // 1.9*2
     {"eps", 0.1},
     {"elec_scaling", 332 * 0.2},   // 1.0

--- a/cpp/src/protac.hpp
+++ b/cpp/src/protac.hpp
@@ -54,6 +54,17 @@ public:
     double e_intra(const RDKit::ROMol* mol) const;
     double score(const std::vector<double>& dihe);
     
+    // 新增score_only功能
+    double score_only(bool verbose = false);
+    double score_only(const std::vector<double>& dihe, bool verbose = false);
+    
+    // 公有访问器方法
+    const std::shared_ptr<RDKit::ROMol>& getProtac() const { return protac_; }
+    const std::vector<std::array<int, 4>>& getRotatableDihedrals() const { return rot_dihe_; }
+    std::vector<Solution>& getSolutions() { return solutions_; }
+    void clearSolutions() { solutions_.clear(); }
+    void addSolution(const Solution& solution) { solutions_.push_back(solution); }
+    
     void output(RDKit::SDWriter& w, 
                 std::ostream& fpro, 
                 int nKeep,

--- a/cpp/src/protein.cpp
+++ b/cpp/src/protein.cpp
@@ -40,16 +40,16 @@ void Protein::ReadProt(const std::string& filename, const std::array<double, 3>&
                 if (atom_it != atomtypes.end()) {
                     auto hbond_it = hbondtypes.find(atp);
                     if (hbond_it != hbondtypes.end()) {
-                        if (hbondtypes[atp]== 2) {
-                            para.push_back(std::make_tuple(std::nullopt, atomtypes[atp], 2));
-                        } else { //hbondtypes[atp]== 3
+                        if (hbondtypes[atp] == 2) {
                             para.push_back(std::make_tuple(std::nullopt, atomtypes[atp], 3));
+                        } else { //hbondtypes[atp] == 3
+                            para.push_back(std::make_tuple(std::nullopt, atomtypes[atp], 2));
                         }
                     } else {
-                        para.push_back(std::make_tuple(std::nullopt, atomtypes[atp], 0));
+                        para.push_back(std::make_tuple(std::nullopt, atomtypes[atp], std::nullopt));
                     }
                 } else {
-                    para.push_back(std::make_tuple(std::nullopt, 0.0, 0));
+                    para.push_back(std::make_tuple(std::nullopt, 0.0, std::nullopt));
                 }
             }
         }

--- a/cpp/src/ternify.hpp
+++ b/cpp/src/ternify.hpp
@@ -18,6 +18,7 @@ struct Parameters {
     int n_keep = 900;
     int n_processes = 1;
     int verbose = 0;
+    bool score_only = false;
     VolRegion interface;
 };
 


### PR DESCRIPTION

1. Keep the force field parameters consistent with the Python version.
2. When optimizing H-consistent parameters (force constants), ensure consistent scoring for the same conformation (strain energy, protein–protein, protein–warhead, etc.), regardless of the hydrogen bond type in the PROTAC and without considering 1-4 scaling.
3. Reorganized the alignment algorithm, including whether to use left or right multiplication and whether to compute the center of mass.
4. Added a `score_only` mode, in which the PROTAC still needs to be aligned with the input `e3.sdf` and `poi.sdf`.
5. Rechecked the grid energy calculation and the storage of hydrogen bond energy (further checking is still needed).
6. Reset the grid space used in `parameters` to 0.3.
